### PR TITLE
add a top-level !user command with subcommands

### DIFF
--- a/fedora/constants.py
+++ b/fedora/constants.py
@@ -1,7 +1,7 @@
 import re
 
 NL = "      \n"
-ALIASES = {"hello": ["hi", "hello2", "hellomynameis"], "user": ["fasinfo"]}
+ALIASES = {}
 MATRIX_USER_RE = re.compile(r"@([^:]+):([^\s]+)")
 # Domains where we can safely use the username as a FAS user
 FAS_MATRIX_DOMAINS = ["fedora.im"]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -17,9 +17,7 @@ async def test_help(bot, plugin):
         "● `!pagureissue <project> <issue_id>` - return a pagure issue\n"
         "● `!whoowns <package>` - Retrieve the owner of a given package\n"
         "● `!group  <subcommand> [...]` - Query information about Fedora Accounts groups\n"
-        "● `!hello [username]` - Return brief information about a Fedora user.\n"
-        "● `!localtime <username>` - Returns the current time of the user.\n"
-        "● `!user [username]` - Return brief information about a Fedora user.\n"
+        "● `!user  <subcommand> [...]` - Get information about Fedora Accounts users\n"
         "● `!bug <bug_id>` - return a bugzilla bug\n"
         "● `!oncall  <subcommand> [...]` - oncall"
     )

--- a/tests/test_fas.py
+++ b/tests/test_fas.py
@@ -106,7 +106,8 @@ async def test_group_members_mentions(bot, plugin, respx_mock, monkeypatch):
 
 
 @pytest.mark.parametrize("pronouns", [None, ["they / them", "mx"]])
-async def test_hello(bot, plugin, respx_mock, pronouns):
+@pytest.mark.parametrize("alias", [None, "hi", "hello", "hello2", "hellomynameis"])
+async def test_user_hello(bot, plugin, respx_mock, pronouns, alias):
     respx_mock.get("http://fasjson.example.com/v1/users/dummy/").mock(
         return_value=httpx.Response(
             200,
@@ -125,7 +126,10 @@ async def test_hello(bot, plugin, respx_mock, pronouns):
         params={"ircnick__exact": "matrix://example.com/dummy"},
     ).mock(return_value=httpx.Response(200, json={"result": []}))
 
-    await bot.send("!hello")
+    if not alias:
+        await bot.send("!user hello")
+    else:
+        await bot.send(f"!{alias}")
     assert len(bot.sent) == 1
     expected = "Dummy User (dummy)"
     if pronouns:
@@ -133,7 +137,8 @@ async def test_hello(bot, plugin, respx_mock, pronouns):
     assert bot.sent[0].content.body == expected
 
 
-async def test_hello_with_username(bot, plugin, respx_mock):
+@pytest.mark.parametrize("alias", [None, "hi", "hello", "hello2", "hellomynameis"])
+async def test_hello_with_username(bot, plugin, respx_mock, alias):
     respx_mock.get("http://fasjson.example.com/v1/users/dummy2/").mock(
         return_value=httpx.Response(
             200,
@@ -151,7 +156,10 @@ async def test_hello_with_username(bot, plugin, respx_mock):
         params={"ircnick__exact": "matrix://example.com/dummy"},
     ).mock(return_value=httpx.Response(200, json={"result": []}))
 
-    await bot.send("!hello dummy2")
+    if not alias:
+        await bot.send("!user hello dummy2")
+    else:
+        await bot.send(f"!{alias} dummy2")
     assert len(bot.sent) == 1
     assert bot.sent[0].content.body == "Dummy User 2 (dummy2)"
 
@@ -182,7 +190,8 @@ async def test_localtime(bot, plugin, respx_mock, monkeypatch):
     assert bot.sent[0].content.body == expected
 
 
-async def test_user_info(bot, plugin, respx_mock):
+@pytest.mark.parametrize("alias", [None, "fasinfo"])
+async def test_user_info(bot, plugin, respx_mock, alias):
     respx_mock.get("http://fasjson.example.com/v1/users/dummy/").mock(
         return_value=httpx.Response(
             200,
@@ -195,7 +204,10 @@ async def test_user_info(bot, plugin, respx_mock):
             },
         )
     )
-    await bot.send("!user dummy")
+    if not alias:
+        await bot.send("!user info dummy")
+    else:
+        await bot.send(f"!{alias} dummy")
     assert len(bot.sent) == 1
     expected = (
         "User: dummy,\n "


### PR DESCRIPTION
This replaces the old !user command (which displayed user info) with a new top level !user command with the following sub-commands (localtime, hello, info).

Had to implement aliases for these 3 subcommands manually, as maubot wont let you alias a command-level to a command + subcommand. So these are done with a passive command.