### PR TITLE
Add !infra status command

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -6,4 +6,5 @@ pagureio_issue_aliases:
   fesco: "fesco"
 paguredistgit_url: https://src.fedoraproject.org
 bodhi_url: https://bodhi.fedoraproject.org
+fedorastatus_url: https://status.fedoraproject.org
 controlroom: ''

--- a/changelog.d/25.added
+++ b/changelog.d/25.added
@@ -1,0 +1,2 @@
+The new !infra status command provides information from http://status.fedoraproject.org about
+known and upcoming outages on Fedora infrastructure.

--- a/fedora/__init__.py
+++ b/fedora/__init__.py
@@ -14,6 +14,7 @@ from .cookie import CookieHandler
 from .db import upgrade_table
 from .distgit import DistGitHandler
 from .fas import FasHandler
+from .infra import InfraHandler
 from .oncall import OnCallHandler
 from .pagureio import PagureIOHandler
 
@@ -32,6 +33,7 @@ class Fedora(Plugin):
         self.register_handler_class(PagureIOHandler(self))
         self.register_handler_class(DistGitHandler(self))
         self.register_handler_class(FasHandler(self))
+        self.register_handler_class(InfraHandler(self))
         self.register_handler_class(BugzillaHandler(self))
         self.register_handler_class(OnCallHandler(self))
         self.register_handler_class(CookieHandler(self))

--- a/fedora/clients/fedorastatus.py
+++ b/fedora/clients/fedorastatus.py
@@ -1,0 +1,32 @@
+from typing import Literal
+
+import httpx
+from pydantic import validate_call
+
+from ..exceptions import InfoGatherError
+
+
+class FedoraStatusClient:
+    def __init__(self, baseurl):
+        self.baseurl = baseurl
+
+    async def _get(self, endpoint, **kwargs) -> httpx.Response:
+        kwargs.setdefault("headers", {})["Content-Type"] = "application/json"
+        async with httpx.AsyncClient() as client:
+            response = await client.get(self.baseurl + endpoint, **kwargs)
+        return response
+
+    def _check_errors(self, response):
+        if response.status_code != 200:
+            raise InfoGatherError(
+                f"Issue querying Fedora Status: {response.status_code}: {response.reason_phrase}"
+            )
+
+    @validate_call
+    async def get_outages(self, outagetype: Literal["ongoing", "planned", "resolved"]):
+        outages = await self._get(
+            f"/{outagetype}.json",
+        )
+        self._check_errors(outages)
+
+        return outages.json()

--- a/fedora/config.py
+++ b/fedora/config.py
@@ -8,4 +8,5 @@ class Config(BaseProxyConfig):
         helper.copy("pagureio_issue_aliases")
         helper.copy("paguredistgit_url")
         helper.copy("bodhi_url")
+        helper.copy("fedorastatus_url")
         helper.copy("controlroom")

--- a/fedora/infra.py
+++ b/fedora/infra.py
@@ -1,0 +1,66 @@
+import logging
+
+from maubot import MessageEvent
+from maubot.handlers import command
+
+from .clients.fedorastatus import FedoraStatusClient
+from .constants import NL
+from .handler import Handler
+
+log = logging.getLogger(__name__)
+
+
+class InfraHandler(Handler):
+    def __init__(self, plugin):
+        super().__init__(plugin)
+        self.fedorastatus_url = plugin.config["fedorastatus_url"]
+        self.fedorastatus = FedoraStatusClient(self.fedorastatus_url)
+
+    @command.new(help="Fedora Infrastructure commands")
+    async def infra(self, evt: MessageEvent) -> None:
+        pass
+
+    @infra.subcommand(name="status", help="get a list of the ongoing and planned outages")
+    async def infra_status(self, evt: MessageEvent) -> None:
+        def format_title(outage):
+            if outage.get("ticket"):
+                return f"**[{outage.get('title')}]({outage.get('ticket')['url']})**"
+            else:
+                return f"**{outage.get('title')}**"
+
+        ongoing = await self.fedorastatus.get_outages("ongoing")
+        ongoing = ongoing.get("outages", [])
+
+        planned = await self.fedorastatus.get_outages("planned")
+        planned = planned.get("outages", [])
+
+        message = f"I checked [Fedora Status]({self.fedorastatus_url}) and there are "
+        if not ongoing and not planned:
+            message = message + f"**no planned or ongoing outages on Fedora Infrastructure.**{NL}"
+        else:
+            message = message + (
+                f"**{len(ongoing)} ongoing** and **{len(planned)} planned** "
+                f"outages on Fedora Infrastructure.{NL}"
+            )
+            if ongoing:
+                message = message + f"##### Ongoing{NL}"
+                for outage in ongoing:
+                    message = message + f" * {format_title(outage)}{NL}"
+                    # TODO: Make these times relative (e.g. started 1 hour ago)
+                    message = message + f"   Started at: {outage['startdate']}{NL}"
+                    message = message + (
+                        f"   Estimated to end: "
+                        f"{outage['enddate'] if outage['enddate'] else 'Unknown'}{NL}"
+                    )
+            if planned:
+                message = message + f"##### Planned{NL}"
+                for outage in planned:
+                    message = message + f" * {format_title(outage)}{NL}"
+                    # TODO: Make these times relative (e.g. started 1 hour ago)
+                    message = message + f"   Scheduled to start at: {outage['startdate']}{NL}"
+                    message = message + (
+                        f"   Scheduled to end at: "
+                        f"{outage['enddate'] if outage['enddate'] else 'Unknown'}{NL}"
+                    )
+
+        await evt.respond(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ httpx
 httpx_gssapi
 maubot
 mautrix
+pydantic
 pytz

--- a/tests/clients/test_fedorastatus.py
+++ b/tests/clients/test_fedorastatus.py
@@ -1,0 +1,44 @@
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from fedora.clients.fedorastatus import FedoraStatusClient
+from fedora.exceptions import InfoGatherError
+
+
+async def test_get_outages(respx_mock):
+    client = FedoraStatusClient("http://status.example.com")
+    json_response = {
+        "outages": [
+            {
+                "title": "Matrix / libera.chat IRC bridge unavailable",
+                "ticket": {
+                    "id": "11460",
+                    "url": "https://pagure.io/fedora-infrastructure/issue/11460",
+                },
+                "startdate": "2023-08-06T12:00:00+0000",
+                "enddate": None,
+            }
+        ]
+    }
+    respx_mock.get("http://status.example.com").mock(
+        return_value=httpx.Response(
+            200,
+            json=json_response,
+        )
+    )
+    response = await client.get_outages("ongoing")
+    assert response == json_response
+
+
+async def test_invalid_outage_type():
+    client = FedoraStatusClient("http://status.example.com")
+    with pytest.raises(ValidationError, match="Input should be 'ongoing', 'planned' or 'resolved'"):
+        await client.get_outages("PANTS")
+
+
+async def test_error_response(respx_mock):
+    client = FedoraStatusClient("http://status.example.com")
+    respx_mock.get("http://status.example.com").mock(return_value=httpx.Response(404))
+    with pytest.raises(InfoGatherError, match="Issue querying Fedora Status: 404: Not Found"):
+        await client.get_outages("ongoing")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ async def plugin(bot, db):
         "pagureio_url": "http://pagure.example.com",
         "paguredistgit_url": "http://src.example.com",
         "bodhi_url": "http://bodhi.example.com",
+        "fedorastatus_url": "http://status.example.com",
         "controlroom": "controlroom",
     }
     config = Config(lambda: test_config, lambda: base_config, lambda c: None)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -23,6 +23,7 @@ async def test_help(bot, plugin):
         "● `!whoowns <package>` - Retrieve the owner of a given package\n"
         "● `!group  <subcommand> [...]` - Query information about Fedora Accounts groups\n"
         "● `!user  <subcommand> [...]` - Get information about Fedora Accounts users\n"
+        "● `!infra  <subcommand> [...]` - Fedora Infrastructure commands\n"
         "● `!bug <bug_id>` - return a bugzilla bug\n"
         "● `!oncall  <subcommand> [...]` - oncall\n"
         "● `!cookie  <subcommand> [...]` - Commands for the cookie system"

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -1,0 +1,138 @@
+import httpx
+import pytest
+
+OUTAGE_FULL = {
+    "title": "thetitle",
+    "ticket": {"id": "1", "url": "https://i.test/1"},
+    "startdate": "2023-08-06T1:00:00+0000",
+    "enddate": "2023-08-06T2:00:00+0000",
+}
+OUTAGE_NO_ENDDATE = {
+    "title": "thetitle",
+    "ticket": {"id": "1", "url": "https://i.test/1"},
+    "startdate": "2023-08-06T1:00:00+0000",
+    "enddate": None,
+}
+OUTAGE_NO_TICKET = {
+    "title": "thetitle",
+    "ticket": None,
+    "startdate": "2023-08-06T1:00:00+0000",
+    "enddate": "2023-08-06T2:00:00+0000",
+}
+OUTAGE_NO_ENDDATE_NO_TICKET = {
+    "title": "thetitle",
+    "ticket": None,
+    "startdate": "2023-08-06T1:00:00+0000",
+    "enddate": None,
+}
+
+
+@pytest.mark.parametrize(
+    "outages",
+    [
+        (
+            [OUTAGE_FULL, OUTAGE_NO_ENDDATE, OUTAGE_NO_ENDDATE_NO_TICKET, OUTAGE_NO_TICKET],
+            [OUTAGE_FULL, OUTAGE_NO_ENDDATE, OUTAGE_NO_ENDDATE_NO_TICKET, OUTAGE_NO_TICKET],
+            (
+                "I checked Fedora Status (http://status.example.com) and there are "
+                "**4 ongoing** and **4 planned** outages on Fedora Infrastructure.\n\n"
+                "##### Ongoing\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: 2023-08-06T2:00:00+0000\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: Unknown\n"
+                "● **thetitle**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: Unknown\n"
+                "● **thetitle**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: 2023-08-06T2:00:00+0000\n"
+                "##### Planned\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: 2023-08-06T2:00:00+0000\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: Unknown\n"
+                "● **thetitle**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: Unknown\n"
+                "● **thetitle**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: 2023-08-06T2:00:00+0000"
+            ),
+        ),
+        (
+            [OUTAGE_FULL, OUTAGE_NO_ENDDATE, OUTAGE_NO_ENDDATE_NO_TICKET, OUTAGE_NO_TICKET],
+            [],
+            (
+                "I checked Fedora Status (http://status.example.com) and there are "
+                "**4 ongoing** and **0 planned** outages on Fedora Infrastructure.\n\n"
+                "##### Ongoing\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: 2023-08-06T2:00:00+0000\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: Unknown\n"
+                "● **thetitle**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: Unknown\n"
+                "● **thetitle**\n"
+                "   Started at: 2023-08-06T1:00:00+0000\n"
+                "   Estimated to end: 2023-08-06T2:00:00+0000"
+            ),
+        ),
+        (
+            [],
+            [OUTAGE_FULL, OUTAGE_NO_ENDDATE, OUTAGE_NO_ENDDATE_NO_TICKET, OUTAGE_NO_TICKET],
+            (
+                "I checked Fedora Status (http://status.example.com) and there are "
+                "**0 ongoing** and **4 planned** outages on Fedora Infrastructure.\n\n"
+                "##### Planned\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: 2023-08-06T2:00:00+0000\n"
+                "● **thetitle (https://i.test/1)**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: Unknown\n"
+                "● **thetitle**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: Unknown\n"
+                "● **thetitle**\n"
+                "   Scheduled to start at: 2023-08-06T1:00:00+0000\n"
+                "   Scheduled to end at: 2023-08-06T2:00:00+0000"
+            ),
+        ),
+        (
+            [],
+            [],
+            (
+                "I checked Fedora Status (http://status.example.com) and there are "
+                "**no planned or ongoing outages on Fedora Infrastructure.**"
+            ),
+        ),
+    ],
+)
+async def test_infra_outages(bot, plugin, respx_mock, outages):
+    ongoing_json_response = {"outages": outages[0]}
+    respx_mock.get("http://status.example.com/ongoing.json").mock(
+        return_value=httpx.Response(
+            200,
+            json=ongoing_json_response,
+        )
+    )
+
+    planned_json_response = {"outages": outages[1]}
+    respx_mock.get("http://status.example.com/planned.json").mock(
+        return_value=httpx.Response(
+            200,
+            json=planned_json_response,
+        )
+    )
+    await bot.send("!infra status")
+    assert len(bot.sent) == 1
+    print(repr(bot.sent[0].content.body))
+    assert bot.sent[0].content.body == outages[2]


### PR DESCRIPTION
Adds the `!infra status` command that returns information from
status.fp.o about current known and planned outages on Fedora
Infrastructure.