### PR TITLE
adds the from_user to the already awarded message

### DIFF
--- a/fedora/cookie.py
+++ b/fedora/cookie.py
@@ -118,7 +118,7 @@ class CookieHandler(Handler):
             )
         except UNIQUE_ERROR:
             return (
-                f"You have already given cookies to {to_user} during the "
+                f"{from_user} has already given cookies to {to_user} during the "
                 f"F{current_release} timeframe"
             )
         total, by_release = await self._get_cookie_totals(to_user)

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -139,7 +139,7 @@ async def test_cookie_give_twice(bot, plugin, respx_mock, db):
     assert len(bot.sent) == 1
     assert (
         bot.sent[0].content.body
-        == "You have already given cookies to foobar during the F38 timeframe"
+        == "dummy has already given cookies to foobar during the F38 timeframe"
     )
 
 


### PR DESCRIPTION
Update as requested by @jwflory to clarify who it was that awarded the cookie historically   