### PR TITLE
Pedantic pretty plurals

### DIFF
--- a/fedora/cookie.py
+++ b/fedora/cookie.py
@@ -124,7 +124,7 @@ class CookieHandler(Handler):
         total, by_release = await self._get_cookie_totals(to_user)
         return (
             f"{from_user} gave a cookie to {to_user}. They now "
-            f"have {total} cookie(s), {by_release[current_release]} of which were obtained "
+            f"have {total} cookie{'' if total==1 else 's'}, {by_release[current_release]} of which were obtained "
             f"in the Fedora {current_release} release cycle"
         )
 

--- a/fedora/cookie.py
+++ b/fedora/cookie.py
@@ -124,7 +124,7 @@ class CookieHandler(Handler):
         total, by_release = await self._get_cookie_totals(to_user)
         return (
             f"{from_user} gave a cookie to {to_user}. They now "
-            f"have {total} cookie{'' if total==1 else 's'}, {by_release[current_release]} of which were obtained "
+            f"have {total} cookie{'' if total==1 else 's'}, {by_release[current_release]} of which {'was' if total==1 else 'were'} obtained "
             f"in the Fedora {current_release} release cycle"
         )
 

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -75,8 +75,8 @@ async def test_cookie_give(bot, plugin, respx_mock, give_command):
     await bot.send(give_command)
     assert len(bot.sent) == 1
     assert bot.sent[0].content.body == (
-        "dummy gave a cookie to foobar. They now have 1 cookie(s), "
-        "1 of which were obtained in the Fedora 38 release cycle"
+        "dummy gave a cookie to foobar. They now have 1 cookie, "
+        "1 of which was obtained in the Fedora 38 release cycle"
     )
 
 
@@ -205,8 +205,8 @@ async def test_cookie_react(bot, plugin, respx_mock, emoji):
     if is_cookie_emoji:
         assert len(bot.sent) == 1
         assert bot.sent[0].content.body == (
-            "dummy gave a cookie to foobar. They now have 1 cookie(s), "
-            "1 of which were obtained in the Fedora 38 release cycle"
+            "dummy gave a cookie to foobar. They now have 1 cookie, "
+            "1 of which was obtained in the Fedora 38 release cycle"
         )
     else:
         assert len(bot.sent) == 0


### PR DESCRIPTION
Make it say "1 cookie" or "2 cookies" instead of "1 cookie(s)" or "2 cookie(s)".

I have not actually tested this. What could go wrong? :)