### PR TITLE
add inline reply to the start of `!user hello` messages

### DIFF
--- a/changelog.d/46.changed
+++ b/changelog.d/46.changed
@@ -1,0 +1,4 @@
+ Previously, `!user hello` messages had no link back to the original command message. 
+ This caused confusion when multiple people called the same command around the 
+ same time. This commit adds an inline-reply (i.e the username of the person that issued 
+ the command) at the start of the message before the response.

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -8,7 +8,7 @@ from maubot.handlers import command
 from .constants import NL
 from .exceptions import InfoGatherError
 from .handler import Handler
-from .utils import get_fasuser, matrix_ids_from_ircnicks, tag_user
+from .utils import get_fasuser, inline_reply, matrix_ids_from_ircnicks, tag_user
 
 log = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ class FasHandler(Handler):
         message = f"{user['human_name']} ({user['username']})"
         if pronouns := user.get("pronouns"):
             message += " - " + " or ".join(pronouns)
-        await evt.respond(message)
+        await inline_reply(evt, message)
 
     async def _user_info(self, evt: MessageEvent, username: str | None) -> None:
         await evt.mark_read()

--- a/fedora/utils.py
+++ b/fedora/utils.py
@@ -93,3 +93,8 @@ def is_text_message(content: BaseMessageEventContent | Obj) -> TypeGuard[TextMes
         # TextMessageEventContent can also be of MessageType.EMOTE, hence the second check
         and content.msgtype in {MessageType.TEXT, MessageType.NOTICE}
     )
+
+
+async def inline_reply(evt: MessageEvent, message: str):
+    displayname = await evt.client.get_displayname(evt.sender)
+    await evt.respond(f"{tag_user(evt.sender,name=displayname)}: {message}")


### PR DESCRIPTION
Previously, user hello messages had no link back to the original command message. This caused confusion when multiple people called the same command around the same time. This commit adds an inline-reply (i.e the user tag at the start of the message) before the response.

This was chosen instead of proper matrix replies since matrix clients tend to reproduce the whole triggering message, which caused a lot of visual noise.

Resolves: #46