### PR TITLE
Differentiate user info & user hello help messages (Fixes #51)

### DIFF
--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -164,7 +164,7 @@ class FasHandler(Handler):
         pass
 
     @user.subcommand(
-        name="hello", 
+        name="hello",
         help=(
             "Return brief information about a Fedora user, including username,"
             " name, and pronouns (if available)."
@@ -185,7 +185,7 @@ class FasHandler(Handler):
         await self._user_hello(evt, username)
 
     @user.subcommand(
-        name="info", 
+        name="info",
         help=(
             "Return detailed information about a Fedora user, including username,"
             " human name, pronouns, creation date, timezone, locale, and GPG key IDs."

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -163,7 +163,7 @@ class FasHandler(Handler):
         """Query information about Fedora groups"""
         pass
 
-    @user.subcommand(name="hello", help="Return brief information about a Fedora user.")
+    @user.subcommand(name="hello", help="Return brief information about a Fedora user, including username, name, and pronouns (if available).")
     @command.argument("username", pass_raw=True, required=False)
     async def user_hello(self, evt: MessageEvent, username: str | None) -> None:
         """
@@ -178,11 +178,11 @@ class FasHandler(Handler):
         """
         await self._user_hello(evt, username)
 
-    @user.subcommand(name="info", help="Return brief information about a Fedora user.")
+    @user.subcommand(name="info", help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.")
     @command.argument("username", pass_raw=True, required=False)
     async def user_info(self, evt: MessageEvent, username: str | None) -> None:
         """
-        Returns a information from Fedora Accounts about the user
+        Returns information from Fedora Accounts about the user
         If no username is provided, defaults to the sender of the message.
 
         #### Arguments ####

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -163,7 +163,13 @@ class FasHandler(Handler):
         """Query information about Fedora groups"""
         pass
 
-    @user.subcommand(name="hello", help="Return brief information about a Fedora user, including username, name, and pronouns (if available).")
+    @user.subcommand(
+        name="hello", 
+        help=(
+            "Return brief information about a Fedora user, including username,"
+            " name, and pronouns (if available)."
+        ),
+    )
     @command.argument("username", pass_raw=True, required=False)
     async def user_hello(self, evt: MessageEvent, username: str | None) -> None:
         """
@@ -178,7 +184,13 @@ class FasHandler(Handler):
         """
         await self._user_hello(evt, username)
 
-    @user.subcommand(name="info", help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.")
+    @user.subcommand(
+        name="info", 
+        help=(
+            "Return detailed information about a Fedora user, including username,"
+            " human name, pronouns, creation date, timezone, locale, and GPG key IDs."
+        ),
+    )
     @command.argument("username", pass_raw=True, required=False)
     async def user_info(self, evt: MessageEvent, username: str | None) -> None:
         """


### PR DESCRIPTION
Description:

This PR updates the help text for the user info and user hello commands within the FasHandler class. The descriptions are now more accurate and clearly distinguish the information provided by each command:

user info: Returns detailed information about a Fedora user.
user hello: Returns a brief introduction of a Fedora user.
This improves the user experience by providing clearer guidance on how to use these commands.

Resolves: #51 

Changes:

Modified help text for user info and user hello commands.
<img width="1672" alt="Screenshot 2024-03-25 at 02 09 01" src="https://github.com/fedora-infra/maubot-fedora/assets/95109808/310dccf7-104d-41ad-96ab-ca78b24698ca">