### PR TITLE
Add User's Group Membership Details to User Info (Fixes #49)

### DIFF
--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -115,7 +115,6 @@ class FasjsonClient:
                 - A list of dictionaries containing group information:
                     - groupname (str): Name of the group.
                     - membership_type (str): "member" or "sponsor" depending on the user's role.
-                - None (if the user is not found or there's an error).
 
         Raises:
             InfoGatherError: If there's an error fetching data from Fasjson or if the user is not found (404).

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -123,8 +123,13 @@ class FasjsonClient:
 
         try:
             response = await self._get("/".join(["users", username, "groups"]), params=params)
-            user_groups = response.json().get("groups", [])
+        except NoResult as e:
+            raise InfoGatherError(
+                f"Sorry, but Fedora Accounts user '{username}' does not exist"
+            ) from e
+        user_groups = response.json().get("groups", [])
 
+        try:
             group_details = []
             for groupname in user_groups:
                 # Fix - i realized at some point that get group membership, just returns members/sponsors in a group
@@ -142,10 +147,5 @@ class FasjsonClient:
             group_details.append({"groupname": groupname, "membership_type": membership_type})
 
             return group_details
-
-        except NoResult as e:
-            raise InfoGatherError(
-                f"Sorry, but Fedora Accounts user '{username}' does not exist"
-            ) from e
         except InfoGatherError as e:
             raise

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -54,7 +54,7 @@ class FasjsonClient:
         return response.json().get("result")
 
     async def get_user(self, username, params=None):
-        """looks up a group by the groupname"""
+        """looks up a user by username"""
         try:
             response = await self._get("/".join(["users", username]), params=params)
         except NoResult as e:
@@ -64,7 +64,7 @@ class FasjsonClient:
         return response.json().get("result")
 
     async def search_users(self, params=None):
-        """looks up a group by the groupname"""
+        """looks up users given a search term"""
         response = await self._get("/".join(["search", "users"]), params=params)
         return response.json().get("result")
 
@@ -101,7 +101,7 @@ class FasjsonClient:
             )
 
         return searchresult[0]
-    
+
     async def get_user_groups(self, username, params=None):
         """
         Retrieves all groups a user belongs to, including membership type (member or sponsor).
@@ -128,7 +128,9 @@ class FasjsonClient:
             group_details = []
             for groupname in user_groups:
 
-                membership_type = await self.get_group_membership(groupname, "sponsors", params=params)
+                membership_type = await self.get_group_membership(
+                    groupname, "sponsors", params=params
+                )
 
                 if membership_type is None:
                     membership_type = "member"
@@ -140,7 +142,8 @@ class FasjsonClient:
             return group_details
 
         except NoResult as e:
-            raise InfoGatherError(f"Sorry, but Fedora Accounts user '{username}' does not exist") from e
+            raise InfoGatherError(
+                f"Sorry, but Fedora Accounts user '{username}' does not exist"
+            ) from e
         except InfoGatherError as e:
             raise
-

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -127,17 +127,19 @@ class FasjsonClient:
 
             group_details = []
             for groupname in user_groups:
-                #Fix - i realized at some point that get group membership, just returns members/sponsors in a group
-                sponsors = await self.get_group_membership(
-                    groupname, "sponsors", params=params
-                )
+                # Fix - i realized at some point that get group membership, just returns members/sponsors in a group
+                sponsors = await self.get_group_membership(groupname, "sponsors", params=params)
 
+            if sponsors is not None:
                 if username in sponsors:
                     membership_type = "sponsor"
                 else:
                     membership_type = "member"
+            else:
+                # Handle the case when sponsors is None (no sponsors for the group)
+                membership_type = "member"
 
-                group_details.append({"groupname": groupname, "membership_type": membership_type})
+            group_details.append({"groupname": groupname, "membership_type": membership_type})
 
             return group_details
 

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -117,7 +117,8 @@ class FasjsonClient:
                     - membership_type (str): "member" or "sponsor" depending on the user's role.
 
         Raises
-            InfoGatherError: If there's an error fetching data from Fasjson or if the user is not found (404).
+            InfoGatherError: If there's an error fetching data from Fasjson or
+            if the user is not found (404).
         """
 
         try:
@@ -128,17 +129,14 @@ class FasjsonClient:
             ) from e
         user_groups = response.json().get("groups", [])
 
-        try:
-            group_details = []
-            for groupname in user_groups:
-                sponsors = await self.get_group_membership(groupname, "sponsors", params=params)
+        group_details = []
+        for groupname in user_groups:
+            sponsors = await self.get_group_membership(groupname, "sponsors", params=params)
 
-                membership_type = "member"
-                if sponsors is not None and username in sponsors:
-                    membership_type = "member"
+            membership_type = "Member"
+            if sponsors is not None and username in sponsors:
+                membership_type = "Sponsor"
 
-                group_details.append({"groupname": groupname, "membership_type": membership_type})
+            group_details.append({"groupname": groupname, "membership_type": membership_type})
 
-            return group_details
-        except InfoGatherError as e:
-            raise
+        return group_details

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -116,7 +116,7 @@ class FasjsonClient:
                     - groupname (str): Name of the group.
                     - membership_type (str): "member" or "sponsor" depending on the user's role.
 
-        Raises:
+        Raises
             InfoGatherError: If there's an error fetching data from Fasjson or if the user is not found (404).
         """
 
@@ -131,19 +131,13 @@ class FasjsonClient:
         try:
             group_details = []
             for groupname in user_groups:
-                # Fix - i realized at some point that get group membership, just returns members/sponsors in a group
                 sponsors = await self.get_group_membership(groupname, "sponsors", params=params)
 
-            if sponsors is not None:
-                if username in sponsors:
-                    membership_type = "sponsor"
-                else:
-                    membership_type = "member"
-            else:
-                # Handle the case when sponsors is None (no sponsors for the group)
                 membership_type = "member"
+                if sponsors is not None and username in sponsors:
+                        membership_type = "member"
 
-            group_details.append({"groupname": groupname, "membership_type": membership_type})
+                group_details.append({"groupname": groupname, "membership_type": membership_type})
 
             return group_details
         except InfoGatherError as e:

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -135,7 +135,7 @@ class FasjsonClient:
 
                 membership_type = "member"
                 if sponsors is not None and username in sponsors:
-                        membership_type = "member"
+                    membership_type = "member"
 
                 group_details.append({"groupname": groupname, "membership_type": membership_type})
 

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -127,15 +127,15 @@ class FasjsonClient:
 
             group_details = []
             for groupname in user_groups:
-
-                membership_type = await self.get_group_membership(
+                #Fix - i realized at some point that get group membership, just returns members/sponsors in a group
+                sponsors = await self.get_group_membership(
                     groupname, "sponsors", params=params
                 )
 
-                if membership_type is None:
-                    membership_type = "member"
-                elif username in membership_type:
+                if username in sponsors:
                     membership_type = "sponsor"
+                else:
+                    membership_type = "member"
 
                 group_details.append({"groupname": groupname, "membership_type": membership_type})
 

--- a/fedora/clients/fasjson.py
+++ b/fedora/clients/fasjson.py
@@ -101,3 +101,29 @@ class FasjsonClient:
             )
 
         return searchresult[0]
+    
+    async def get_user_groups(self, username, params=None):
+        """
+        Retrieves all groups a user belongs to using the Fasjson API.
+
+        Args:
+            username (str): Username of the user to query.
+            params (dict, optional): Additional query parameters to include in the request.
+
+        Returns:
+            List[str] or None:
+                - A list of group names the user belongs to (if found).
+                - None (if the user is not found or there's an error).
+
+        Raises:
+            InfoGatherError: If there's an error fetching data from Fasjson or if the user is not found (404).
+        """
+
+        try:
+            response = await self._get("/".join(["users", username, "groups"]), params=params)
+            return response.json().get("groups")
+
+        except NoResult as e:
+            raise InfoGatherError(f"Sorry, but Fedora Accounts user '{username}' does not exist") from e
+        except InfoGatherError as e:
+            raise

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -174,6 +174,7 @@ class FasHandler(Handler):
         pass
 
     @user.subcommand(
+        name="hello",
         help=(
             "Return brief information about a Fedora user, including username,"
             " name, and pronouns (if available)."

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -163,7 +163,7 @@ class FasHandler(Handler):
         """Query information about Fedora groups"""
         pass
 
-    @user.subcommand(name="hello", help="Return brief information about a Fedora user.")
+    @user.subcommand(name="hello", help="Return brief information about a Fedora user, including username, name, and pronouns (if available).")
     @command.argument("username", pass_raw=True, required=False)
     async def user_hello(self, evt: MessageEvent, username: str | None) -> None:
         """
@@ -178,11 +178,11 @@ class FasHandler(Handler):
         """
         await self._user_hello(evt, username)
 
-    @user.subcommand(name="info", help="Return brief information about a Fedora user.")
+    @user.subcommand(name="info", help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.")
     @command.argument("username", pass_raw=True, required=False)
     async def user_info(self, evt: MessageEvent, username: str | None) -> None:
         """
-        Returns a information from Fedora Accounts about the user
+        Returns information from Fedora Accounts about the user
         If no username is provided, defaults to the sender of the message.
 
         #### Arguments ####

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -132,15 +132,14 @@ class FasHandler(Handler):
             f"Creation: {user.get('creation')},{NL}"
             f"Timezone: {user.get('timezone')},{NL}"
             f"Locale: {user.get('locale')},{NL}"
-            f"GPG Key IDs: {' and '.join(k for k in user['gpgkeyids'] or ['None'])}{NL}"
+            f"GPG Key IDs: {' and '.join(k for k in user['gpgkeyids'] or ['None'])},{NL}"
         )
 
-        if groups:
-            group_info = [
-                f"Group: {group['groupname']} - Role: {group['membership_type']}"
-                for group in groups
-            ]
-            respond_message += f"User Groups: {', '.join(group_info)}{NL}"
+        group_info = [
+            f"Group: {group['groupname']} - Role: {group['membership_type']}" for group in groups
+        ]
+
+        respond_message += f"User Groups: {', '.join(group_info) if groups else 'None'}{NL}"
 
         await evt.respond(respond_message)
 

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -120,7 +120,7 @@ class FasHandler(Handler):
         await evt.mark_read()
         try:
             user = await get_fasuser(username or evt.sender, evt, self.plugin.fasjsonclient)
-            groups = await self.plugin.fasjsonclient.get_user_groups(user.get('username'))
+            groups = await self.plugin.fasjsonclient.get_user_groups(user.get("username"))
         except InfoGatherError as e:
             await evt.respond(e.message)
             return
@@ -169,7 +169,10 @@ class FasHandler(Handler):
         """Query information about Fedora groups"""
         pass
 
-    @user.subcommand(name="hello", help="Return brief information about a Fedora user, including username, name, and pronouns (if available).")
+    @user.subcommand(
+        name="hello",
+        help="Return brief information about a Fedora user, including username, name, and pronouns (if available).",
+    )
     @command.argument("username", pass_raw=True, required=False)
     async def user_hello(self, evt: MessageEvent, username: str | None) -> None:
         """
@@ -184,7 +187,10 @@ class FasHandler(Handler):
         """
         await self._user_hello(evt, username)
 
-    @user.subcommand(name="info", help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.")
+    @user.subcommand(
+        name="info",
+        help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.",
+    )
     @command.argument("username", pass_raw=True, required=False)
     async def user_info(self, evt: MessageEvent, username: str | None) -> None:
         """

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -120,11 +120,12 @@ class FasHandler(Handler):
         await evt.mark_read()
         try:
             user = await get_fasuser(username or evt.sender, evt, self.plugin.fasjsonclient)
+            groups = await self.plugin.fasjsonclient.get_user_groups(user.get('username'))
         except InfoGatherError as e:
             await evt.respond(e.message)
             return
 
-        await evt.respond(
+        respond_message = (
             f"User: {user.get('username')},{NL}"
             f"Name: {user.get('human_name')},{NL}"
             f"Pronouns: {' or '.join(user.get('pronouns') or ['unset'])},{NL}"
@@ -133,6 +134,11 @@ class FasHandler(Handler):
             f"Locale: {user.get('locale')},{NL}"
             f"GPG Key IDs: {' and '.join(k for k in user['gpgkeyids'] or ['None'])}{NL}"
         )
+
+        if groups:
+            respond_message += f"Groups : {', '.join(groups)}{NL}"
+
+        await evt.respond(respond_message)
 
     async def _user_localtime(self, evt: MessageEvent, username: str | None) -> None:
         await evt.mark_read()

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -136,7 +136,11 @@ class FasHandler(Handler):
         )
 
         if groups:
-            respond_message += f"Groups : {', '.join(groups)}{NL}"
+            group_info = [
+                f"Group: {group['groupname']} - Role: {group['membership_type']}"
+                for group in groups
+            ]
+            respond_message += f"User Groups: {', '.join(group_info)}{NL}"
 
         await evt.respond(respond_message)
 

--- a/tests/clients/test_fasjson.py
+++ b/tests/clients/test_fasjson.py
@@ -192,7 +192,7 @@ async def test_get_user_groups(monkeypatch, username, expected_url):
     monkeypatch.setattr(client, "_get", mock__get)
 
     response = await client.get_user_groups(username)
-    
+
     groups = result
     assert isinstance(groups, list)
     assert all(group in result for group in groups)

--- a/tests/clients/test_fasjson.py
+++ b/tests/clients/test_fasjson.py
@@ -194,7 +194,7 @@ async def test_get_user_groups(monkeypatch, username, expected_url):
     response = await client.get_user_groups(username)
 
     groups = result
-    assert isinstance(groups, list)
+    assert isinstance(response, list)
     assert all(group in result for group in groups)
 
 

--- a/tests/test_fas.py
+++ b/tests/test_fas.py
@@ -303,6 +303,13 @@ async def test_user_info(bot, plugin, respx_mock, alias):
             },
         )
     )
+
+    respx_mock.get("http://fasjson.example.com/v1/users/dummy/groups/").mock(
+        return_value=httpx.Response(
+            200,
+            json={"groups": []},
+        )
+    )
     if not alias:
         await bot.send("!user info dummy")
     else:


### PR DESCRIPTION

## Add User Group Membership Details to Fas Info Command

**Description:**

This pull request modifies the `FasHandler` class to enhance the `user_info` command by displaying a user's Fedora Accounts group memberships along with their membership types (member or sponsor). 
PR aims to fix #49 
**Changes:**

- Implemented the get_user_groups function. The modifications improve how the function gathers and presents user group membership information.
 The function no longer relies solely on the initial groups list returned by the API.
 It iterates through each group name and performs an additional get_group_membership call for sponsors specifically.
    * Based on the results of the additional call, it assigns the appropriate membership type ("member" or "sponsor") to each group.
- The `_user_info` function is updated to iterate through the user's retrieved groups (a dictionary with group names as keys and membership types as values).
- For each group, it combines the group name and membership type into a single string using f-strings for clear formatting.
- These formatted strings are appended to a list, which is then joined with commas and added to the response message as the "Groups :" section.

**Benefits:**

- Provides more comprehensive user information by including membership details.
- Enhances the user experience by offering a clearer picture of a user's involvement in Fedora Accounts groups.

**Implementation:**

The following code snippet demonstrates the changes made to the `_user_info` function:

```python
    async def _user_info(self, evt: MessageEvent, username: str | None) -> None:
        await evt.mark_read()
        try:
            user = await get_fasuser(username or evt.sender, evt, self.plugin.fasjsonclient)
            groups = await self.plugin.fasjsonclient.get_user_groups(user.get("username"))
        except InfoGatherError as e:
            await evt.respond(e.message)
            return

        respond_message = (
            f"User: {user.get('username')},{NL}"
            f"Name: {user.get('human_name')},{NL}"
            f"Pronouns: {' or '.join(user.get('pronouns') or ['unset'])},{NL}"
            f"Creation: {user.get('creation')},{NL}"
            f"Timezone: {user.get('timezone')},{NL}"
            f"Locale: {user.get('locale')},{NL}"
            f"GPG Key IDs: {' and '.join(k for k in user['gpgkeyids'] or ['None'])}{NL}"
        )

        if groups:
            respond_message += f"Groups : {', '.join(groups)}{NL}"

        await evt.respond(respond_message)
```

Implemented `get_user_groups` function
```
    async def get_user_groups(self, username, params=None):
        try:
            response = await self._get("/".join(["users", username, "groups"]), params=params)
            user_groups = response.json().get("groups", [])

            group_details = []
            for groupname in user_groups:

                membership_type = await self.get_group_membership(
                    groupname, "sponsors", params=params
                )

                if membership_type is None:
                    membership_type = "member"
                elif username in membership_type:
                    membership_type = "sponsor"

                group_details.append({"groupname": groupname, "membership_type": membership_type})

            return group_details

        except NoResult as e:
            raise InfoGatherError(
                f"Sorry, but Fedora Accounts user '{username}' does not exist"
            ) from e
        except InfoGatherError as e:
            raise

```

**Testing:**

- Unit tests were be updated to verify the correct retrieval and display of user group membership details within the `user_info` command response.


This pull request aims to improve the user experience of the `user_info` command by providing more informative group membership details. I appreciate your review and feedback.

Below are the screenshots of testcases passed

<img width="1672" alt="Screenshot 2024-03-26 at 00 03 20" src="https://github.com/fedora-infra/maubot-fedora/assets/95109808/c043463e-9fbe-432c-819d-b60214ba4427">

<img width="1672" alt="Screenshot 2024-03-26 at 00 04 21" src="https://github.com/fedora-infra/maubot-fedora/assets/95109808/3dcaffc2-10d5-4688-8647-b95ab017fee7">
