### PR TITLE
Fix User Timezone Null issue (Fixes #71)

### DIFF
--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -163,7 +163,10 @@ class FasHandler(Handler):
         """Query information about Fedora groups"""
         pass
 
-    @user.subcommand(name="hello", help="Return brief information about a Fedora user, including username, name, and pronouns (if available).")
+    @user.subcommand(
+        name="hello",
+        help="Return brief information about a Fedora user, including username, name, and pronouns (if available).",
+    )
     @command.argument("username", pass_raw=True, required=False)
     async def user_hello(self, evt: MessageEvent, username: str | None) -> None:
         """
@@ -178,7 +181,10 @@ class FasHandler(Handler):
         """
         await self._user_hello(evt, username)
 
-    @user.subcommand(name="info", help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.")
+    @user.subcommand(
+        name="info",
+        help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.",
+    )
     @command.argument("username", pass_raw=True, required=False)
     async def user_info(self, evt: MessageEvent, username: str | None) -> None:
         """

--- a/fedora/fas.py
+++ b/fedora/fas.py
@@ -163,7 +163,7 @@ class FasHandler(Handler):
         """Query information about Fedora groups"""
         pass
 
-    @user.subcommand(name="hello", help="Return brief information about a Fedora user.")
+    @user.subcommand(name="hello", help="Return brief information about a Fedora user, including username, name, and pronouns (if available).")
     @command.argument("username", pass_raw=True, required=False)
     async def user_hello(self, evt: MessageEvent, username: str | None) -> None:
         """
@@ -178,11 +178,11 @@ class FasHandler(Handler):
         """
         await self._user_hello(evt, username)
 
-    @user.subcommand(name="info", help="Return brief information about a Fedora user.")
+    @user.subcommand(name="info", help="Return detailed information about a Fedora user, including username, human name, pronouns, creation date, timezone, locale, and GPG key IDs.")
     @command.argument("username", pass_raw=True, required=False)
     async def user_info(self, evt: MessageEvent, username: str | None) -> None:
         """
-        Returns a information from Fedora Accounts about the user
+        Returns information from Fedora Accounts about the user
         If no username is provided, defaults to the sender of the message.
 
         #### Arguments ####

--- a/fedora/infra.py
+++ b/fedora/infra.py
@@ -101,7 +101,10 @@ class InfraHandler(Handler):
             # Just grab the first mxid in the users list on fas
             mxid = mxids[0]
         try:
-            await self.plugin.database.execute(dbq, fasusername, mxid, user.get("timezone", "UTC"))
+            timezone_to_insert = user.get("timezone")
+            if timezone_to_insert is None:
+                timezone_to_insert = "UTC"
+            await self.plugin.database.execute(dbq, fasusername, mxid, timezone_to_insert)
         except UNIQUE_ERROR:
             await evt.respond(f"{fasusername} is already on the oncall list")
             return

--- a/fedora/infra.py
+++ b/fedora/infra.py
@@ -101,9 +101,7 @@ class InfraHandler(Handler):
             # Just grab the first mxid in the users list on fas
             mxid = mxids[0]
         try:
-            timezone_to_insert = user.get("timezone")
-            if timezone_to_insert is None:
-                timezone_to_insert = "UTC"
+            timezone_to_insert = user.get("timezone", "UTC")
             await self.plugin.database.execute(dbq, fasusername, mxid, timezone_to_insert)
         except UNIQUE_ERROR:
             await evt.respond(f"{fasusername} is already on the oncall list")

--- a/fedora/infra.py
+++ b/fedora/infra.py
@@ -101,8 +101,9 @@ class InfraHandler(Handler):
             # Just grab the first mxid in the users list on fas
             mxid = mxids[0]
         try:
-            timezone_to_insert = user.get("timezone", "UTC")
-            await self.plugin.database.execute(dbq, fasusername, mxid, timezone_to_insert)
+            await self.plugin.database.execute(
+                dbq, fasusername, mxid, user.get("timezone", "UTC") or "UTC"
+            )
         except UNIQUE_ERROR:
             await evt.respond(f"{fasusername} is already on the oncall list")
             return

--- a/tests/test_infra_oncall.py
+++ b/tests/test_infra_oncall.py
@@ -67,10 +67,14 @@ async def test_oncall_add(bot, plugin, db, respx_mock, ircnick):
     current_value = await db.fetch("SELECT * FROM oncall")
     assert len(current_value) == 1
     assert current_value[0]["username"] == "dummy"
-    if ircnick == "irc:///dummyirc":
-        assert current_value[0]["mxid"] == "@dummy:fedora.im"
-    else:
-        assert current_value[0]["mxid"] == "@dummymx:example.com"
+    assert (
+        current_value[0]["mxid"] == "@dummy:fedora.im"
+        if ircnick == "irc:///dummyirc"
+        else "@dummymx:example.com"
+    )
+
+    # Check if the timezone is set to UTC (default) when not provided by FAS
+    assert current_value[0]["timezone"] == "UTC"
 
 
 async def test_oncall_add_empty(bot, plugin, db, respx_mock):

--- a/tests/test_infra_oncall.py
+++ b/tests/test_infra_oncall.py
@@ -71,10 +71,7 @@ async def test_oncall_add(bot, plugin, db, respx_mock, ircnick, response):
     )
     await bot.send("!infra oncall add dummy", room_id="controlroom")
     assert len(bot.sent) == 1
-
-    expected_timezone = "UTC" if response.get("timezone") is None else response.get("timezone")
-    if expected_timezone:
-        expected_message = "dummy has been added to the oncall list"
+    expected_message = "dummy has been added to the oncall list"
     assert bot.sent[0].content.body == expected_message
 
     current_value = await db.fetch("SELECT * FROM oncall")

--- a/tests/test_infra_oncall.py
+++ b/tests/test_infra_oncall.py
@@ -47,23 +47,35 @@ async def test_oncall_list(bot, plugin, db, freeze_datetime, listcommands):
     assert bot.sent[0].content.body == expected
 
 
-@pytest.mark.parametrize("ircnick", ["irc:///dummyirc", "matrix://example.com/dummymx"])
-async def test_oncall_add(bot, plugin, db, respx_mock, ircnick):
+@pytest.fixture
+def ircnick(response):
+    if "ircnicks" in response and len(response["ircnicks"]) > 0:
+        return response["ircnicks"][0]
+    else:
+        return "irc:///dummyirc"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"username": "dummy", "ircnicks": ["irc:///dummyirc"], "timezone": None},
+        {"username": "dummy", "ircnicks": ["matrix://example.com/dummymx"]},
+    ],
+)
+async def test_oncall_add(bot, plugin, db, respx_mock, ircnick, response):
     respx_mock.get("http://fasjson.example.com/v1/users/dummy/").mock(
         return_value=httpx.Response(
             200,
-            json={
-                "result": {
-                    "username": "dummy",
-                    "ircnicks": [ircnick],
-                }
-            },
+            json={"result": response},
         )
     )
     await bot.send("!infra oncall add dummy", room_id="controlroom")
     assert len(bot.sent) == 1
-    expected = "dummy has been added to the oncall list"
-    assert bot.sent[0].content.body == expected
+
+    expected_timezone = "UTC" if response.get("timezone") is None else response.get("timezone")
+    expected_message = f"dummy has been added to the oncall list"
+    assert bot.sent[0].content.body == expected_message
+
     current_value = await db.fetch("SELECT * FROM oncall")
     assert len(current_value) == 1
     assert current_value[0]["username"] == "dummy"

--- a/tests/test_infra_oncall.py
+++ b/tests/test_infra_oncall.py
@@ -73,7 +73,8 @@ async def test_oncall_add(bot, plugin, db, respx_mock, ircnick, response):
     assert len(bot.sent) == 1
 
     expected_timezone = "UTC" if response.get("timezone") is None else response.get("timezone")
-    expected_message = f"dummy has been added to the oncall list"
+    if expected_timezone:
+        expected_message = "dummy has been added to the oncall list"
     assert bot.sent[0].content.body == expected_message
 
     current_value = await db.fetch("SELECT * FROM oncall")


### PR DESCRIPTION
Solves #71 
**Title:** Fix User Timezone Null Issue (Issue #71) and Add Tests (#77)

**Description:**

This pull request addresses two key improvements to the on-call management system:

1. **Fixes Null Timezone Error:** Previously, attempting to add a user to the on-call list would silently fail (on the Matrix side) if their timezone wasn't defined in Fedora Accounts. This PR introduces a fallback mechanism that gracefully handles users without a set timezone by using "UTC" as the default.

   - **Issue:** #71
   - **Description:** The code attempted to insert the user's timezone into the database, but it raised a `NotNullViolationError` if the user hadn't set a timezone.
   - **Solution:** The code now retrieves the user's timezone and defaults to "UTC" if it's `None`. This ensures users can be added to the on-call list regardless of their timezone preference.

**Additional Notes:**

- I addressed code formatting with Black and corrected docstrings in `fasjson.py`.
- Feel free to review the associated commits (linked in the description) for more details.

**Testing Instructions:**

To verify the changes in this PR, please run the test using pytest

```bash
pytest tests/fedora_infra_oncall.py
```

This will execute the unit tests for the on-call list functionality.

**Reviewers:**

@ryanlerch (opened Issue #71)
@KimFarida (implemented code changes and tests)

I welcome your feedback and look forward to merging this PR!
