### PR TITLE
Giving cookies does not work for clients that url encode usernames

### DIFF
--- a/changelog.d/90.docs
+++ b/changelog.d/90.docs
@@ -1,0 +1,4 @@
+ Previously, giving cookies would fail when using the username++ syntax due to some matrix
+ clients url-encoding usernames. This commit adds an a call to urllib.parse.unquote
+ to the username processing portion of the cookie.py give() function to ensure that any
+ url-encoding in usernames is stripped out before further processing of cookies.

--- a/fedora/cookie.py
+++ b/fedora/cookie.py
@@ -5,6 +5,7 @@ from maubot import MessageEvent
 from maubot.handlers import command, event
 from maubot_fedora_messages import GiveCookieV1
 from mautrix.types import EventType
+from urllib.parse import unquote
 
 from .clients.bodhi import BodhiClient
 from .constants import NL
@@ -98,6 +99,7 @@ class CookieHandler(Handler):
         return total, by_release
 
     async def give(self, sender: str, to_user: str) -> str:
+        sender = unquote(sender)
         from_user = await get_fasuser_from_matrix_id(sender, self.plugin.fasjsonclient)
         from_user = from_user["username"]
         if from_user == to_user:

--- a/fedora/cookie.py
+++ b/fedora/cookie.py
@@ -1,11 +1,11 @@
 import logging
 import re
+from urllib.parse import unquote
 
 from maubot import MessageEvent
 from maubot.handlers import command, event
 from maubot_fedora_messages import GiveCookieV1
 from mautrix.types import EventType
-from urllib.parse import unquote
 
 from .clients.bodhi import BodhiClient
 from .constants import NL


### PR DESCRIPTION
I use nheko as my matrix client and have noticed that i cannot give people cookies via the "username++" method because the following happens.

![Screenshot_20240626_085851](https://github.com/fedora-infra/maubot-fedora/assets/17362949/044c4cb9-7f67-46a3-a1fb-5a0b8966f3e7)


This PR checks for this and url decodes the username before processing it