### PR TITLE
Update `!fesco` and `!fpc` aliases to account for Forgejo migration; fix tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
           dnf install -y krb5-devel libpq-devel gettext python-tox
 
       - name: execute tox
-        run: tox -- -v
+        run: tox
 
   deployment:
     name: Deployment

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -2,10 +2,10 @@ fasjson_url: https://fasjson.fedoraproject.org
 pagureio_url: https://pagure.io
 pagureio_issue_aliases:
   fpc: "packaging-committee"
-  fesco: "fesco"
 forge_url: https://forge.fedoraproject.org
 forge_aliases:
   epel: ["issue", "epel", "steering"]
+  fesco: ["issue", "fesco", "tickets"]
   ticket: ["issue", "infra", "tickets"]
   releng: ["issue", "releng", "tickets"]
 paguredistgit_url: https://src.fedoraproject.org

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -1,11 +1,11 @@
 fasjson_url: https://fasjson.fedoraproject.org
 pagureio_url: https://pagure.io
-pagureio_issue_aliases:
-  fpc: "packaging-committee"
+pagureio_issue_aliases: {}
 forge_url: https://forge.fedoraproject.org
 forge_aliases:
   epel: ["issue", "epel", "steering"]
   fesco: ["issue", "fesco", "tickets"]
+  fpc: ["issue", "packaging", "guidelines"]
   ticket: ["issue", "infra", "tickets"]
   releng: ["issue", "releng", "tickets"]
 paguredistgit_url: https://src.fedoraproject.org

--- a/changelog.d/153.changed
+++ b/changelog.d/153.changed
@@ -1,0 +1,1 @@
+Switch !fpc command from pagure to forge

--- a/changelog.d/154.changed
+++ b/changelog.d/154.changed
@@ -1,0 +1,1 @@
+Update !fesco command alias to account for migration to forgejo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,10 @@ async def plugin(bot, db):
         "fasjson_url": "http://fasjson.example.com",
         "pagureio_url": "http://pagure.example.com",
         "forge_url": "http://forge.example.com",
+        "pagureio_issue_aliases": {
+            # Made up repo name for testing purpuses
+            "repofoo": "repofoo-project"
+        },
         "forge_aliases": {
             "epel": ["issue", "epel", "steering"],
             "edpr": ["pr", "epel", "docs"],

--- a/tests/test_pagure.py
+++ b/tests/test_pagure.py
@@ -11,8 +11,7 @@ import fedora
     "command,project",
     [
         ("pagureissue dummy-project", "dummy-project"),
-        ("fpc", "packaging-committee"),
-        ("fesco", "fesco"),
+        ("repofoo", "repofoo-project"),
     ],
 )
 async def test_pagureissue(bot, plugin, respx_mock, command, project):
@@ -123,11 +122,11 @@ async def test_issue_notfound(bot, plugin, respx_mock):
 @pytest.mark.parametrize(
     "command,result",
     [
-        ("!fpc", ["packaging-committee", ""]),
-        ("!fpc 1234", ["packaging-committee", "1234"]),
-        ("!fpcd 1234", []),
-        ("a!fpcd 1234", []),
-        ("!fpc 1234 1234", ["packaging-committee", "1234 1234"]),
+        ("!repofoo", ["repofoo-project", ""]),
+        ("!repofoo 1234", ["repofoo-project", "1234"]),
+        ("!repofood 1234", []),
+        ("a!repofood 1234", []),
+        ("!repofoo 1234 1234", ["repofoo-project", "1234 1234"]),
     ],
 )
 async def test_pagureissue_regex(bot, plugin, monkeypatch, command, result):


### PR DESCRIPTION
Closes: #153
Closes: #154

The two PRs conflict with each other and both require the same test changes, so I applied them all together in this PR. Original authorship of the commits is maintained.